### PR TITLE
Decouple basewidth

### DIFF
--- a/views/MenuView.js
+++ b/views/MenuView.js
@@ -12,7 +12,10 @@ import menus.views.components.DialogBackgroundView as DialogBackgroundView;
 
 exports = Class(DialogBackgroundView, function (supr) {
 	this.init = function (opts) {
-		var width = opts.width || GC.app.baseWidth - 80;
+		this.baseWidth = opts.baseWidth || GC.app.baseWidth;
+		this.baseHeight = opts.baseHeight || GC.app.baseHeight;
+
+		var width = opts.width || this.baseWidth - 80;
 
 		supr(this, 'init', arguments);
 
@@ -33,8 +36,8 @@ exports = Class(DialogBackgroundView, function (supr) {
 
 		this._dialogView = new BoxDialogView({
 			superview: this._dialogContainerView,
-			x: (GC.app.baseWidth - width) * 0.5,
-			y: GC.app.baseHeight * 0.5 - height * 0.5,
+			x: (this.baseWidth - width) * 0.5,
+			y: this.baseHeight * 0.5 - height * 0.5,
 			width: width,
 			height: height,
 			title: opts.title,

--- a/views/MenuView.js
+++ b/views/MenuView.js
@@ -12,8 +12,8 @@ import menus.views.components.DialogBackgroundView as DialogBackgroundView;
 
 exports = Class(DialogBackgroundView, function (supr) {
 	this.init = function (opts) {
-		this.baseWidth = opts.baseWidth || GC.app.baseWidth;
-		this.baseHeight = opts.baseHeight || GC.app.baseHeight;
+		this.baseWidth = opts.baseWidth || (opts.superview ? opts.superview.style.width : undefined) || GC.app.baseWidth;
+		this.baseHeight = opts.baseHeight || (opts.superview ? opts.superview.style.height : undefined) || GC.app.baseHeight;
 
 		var width = opts.width || this.baseWidth - 80;
 

--- a/views/MenuView.js
+++ b/views/MenuView.js
@@ -12,8 +12,8 @@ import menus.views.components.DialogBackgroundView as DialogBackgroundView;
 
 exports = Class(DialogBackgroundView, function (supr) {
 	this.init = function (opts) {
-		this.baseWidth = opts.baseWidth || (opts.superview ? opts.superview.style.width : undefined) || GC.app.baseWidth;
-		this.baseHeight = opts.baseHeight || (opts.superview ? opts.superview.style.height : undefined) || GC.app.baseHeight;
+		this.baseWidth = opts.baseWidth || GC.app.baseWidth || (opts.superview ? opts.superview.style.width : undefined);
+		this.baseHeight = opts.baseHeight || GC.app.baseHeight || (opts.superview ? opts.superview.style.height : undefined);
 
 		var width = opts.width || this.baseWidth - 80;
 

--- a/views/MenuView.js
+++ b/views/MenuView.js
@@ -12,13 +12,9 @@ import menus.views.components.DialogBackgroundView as DialogBackgroundView;
 
 exports = Class(DialogBackgroundView, function (supr) {
 	this.init = function (opts) {
-		this.baseWidth = opts.baseWidth || GC.app.baseWidth || (opts.superview ? opts.superview.style.width : undefined);
-		this.baseHeight = opts.baseHeight || GC.app.baseHeight || (opts.superview ? opts.superview.style.height : undefined);
-
-		var width = opts.width || this.baseWidth - 80;
-
 		supr(this, 'init', arguments);
 
+		var width = opts.width || this.baseWidth - 80;
 		var height = 140;
 		var items = opts.items;
 		for (var i = 0; i < items.length; i++) {

--- a/views/components/DialogBackgroundView.js
+++ b/views/components/DialogBackgroundView.js
@@ -6,11 +6,14 @@ import menus.constants.menuConstants as menuConstants;
 
 exports = Class(View, function (supr) {
 	this.init = function (opts) {
+		this.baseWidth = opts.baseWidth || GC.app.baseWidth || (opts.superview ? opts.superview.style.width : undefined);
+		this.baseHeight = opts.baseHeight || GC.app.baseHeight || (opts.superview ? opts.superview.style.height : undefined);
+
 		// Don't merge but overwrite...
 		opts.x = 0;
 		opts.y = 0;
-		opts.width = GC.app.baseWidth;
-		opts.height = GC.app.baseHeight;
+		opts.width = this.baseWidth;
+		opts.height = this.baseHeight;
 		opts.visible = false;
 
 		supr(this, 'init', [opts]);
@@ -23,8 +26,8 @@ exports = Class(View, function (supr) {
 				superview: this,
 				x: 0,
 				y: 0,
-				width: GC.app.baseWidth,
-				height: GC.app.baseHeight,
+				width: this.baseWidth,
+				height: this.baseHeight,
 				backgroundColor: 'rbga(0, 0, 0)'
 			});
 		}
@@ -34,8 +37,8 @@ exports = Class(View, function (supr) {
 			superview: this,
 			x: 0,
 			y: 0,
-			width: GC.app.baseWidth,
-			height: GC.app.baseHeight
+			width: this.baseWidth,
+			height: this.baseHeight
 		});
 	};
 
@@ -52,7 +55,7 @@ exports = Class(View, function (supr) {
 
 		switch (this._opts.showTransitionMethod || menuConstants.DIALOG.SHOW_TRANSITION_METHOD) {
 			case menuConstants.transitionMethod.SLIDE:
-				dialogContainerStyle.x = -GC.app.baseWidth;
+				dialogContainerStyle.x = -this.baseWidth;
 				dialogContainerStyle.r = 0;
 				dialogContainerStyle.opacity = 1;
 				dialogContainerStyle.scale = 1;
@@ -116,7 +119,7 @@ exports = Class(View, function (supr) {
 
 		switch (this._opts.hideTransitionMethod || menuConstants.DIALOG.HIDE_TRANSITION_METHOD) {
 			case menuConstants.transitionMethod.SLIDE:
-				a = animate(dialogContainerView).then({x: GC.app.baseWidth}, time);
+				a = animate(dialogContainerView).then({x: this.baseWidth}, time);
 				break;
 
 			case menuConstants.transitionMethod.SCALE:


### PR DESCRIPTION
MenuView no longer relies on `GC.app.baseWidth` and `GC.app.baseHeight` in order to size menus. The old mechanism is supported, but two new mechanisms are added. The three mechanisms are listed below in priority order.

First, explicit bounds can be supplied via the `baseWidth` and `baseHeight` values in the initialization options hash.

Second, if the `superview` value is supplied in the options hash, the superview's style `width` and `height` are used as the bounds.

Finally, if no bounds can be inferred, the code falls back on `GC.app.baseWidth` and `GC.app.baseHeight`
